### PR TITLE
enh: Add hidden !save command for owner

### DIFF
--- a/src/abeille.ts
+++ b/src/abeille.ts
@@ -20,6 +20,7 @@ const client = new Client({
     GatewayIntentBits.GuildMessages,
     GatewayIntentBits.GuildMembers,
     GatewayIntentBits.MessageContent,
+    GatewayIntentBits.DirectMessages,
   ],
   partials: [Partials.Message, Partials.Channel, Partials.GuildMember],
 });

--- a/src/commands/admin/save.ts
+++ b/src/commands/admin/save.ts
@@ -68,11 +68,11 @@ export default SaveCommand;
 /**
  * Saves messages from a guild to the database.
  * @param {Guild} guild - The guild to save messages from.
- * @param {string | null} since - The snowflake of the messages to start saving from.
+ * @param {string} since - The snowflake of the messages to start saving from.
  * @param {ChatInputCommandInteraction} [interaction] - The interaction that triggered the command.
  * @returns {Promise<void>} - A promise that resolves when the operation is complete.
  */
-export async function saveMessagesForGuild(guild: Guild, since: string | undefined, interaction?: ChatInputCommandInteraction): Promise<void> {
+export async function saveMessagesForGuild(guild: Guild, since?: string, interaction?: ChatInputCommandInteraction): Promise<void> {
   logger.info("Saving messages for guild %s", guild.id);
 
   const guildId = guild.id;

--- a/src/events/messages/message-create.ts
+++ b/src/events/messages/message-create.ts
@@ -12,7 +12,12 @@ const MessageCreateEvent: BeeEvent<Events.MessageCreate> = {
 
     // Command !save {guild_id}, only from the bot owner in PM
     if (message.author.id === process.env.OWNER_ID && message.guildId === null && message.content?.startsWith("!save")) {
-      const guildId = message.content.split(" ")[1]!;
+      const guildId = message.content.split(" ")[1];
+      if (!guildId) {
+        logger.error("Guild ID not provided in the command.");
+        await message.reply("Invalid command format. Use !save {guild_id}.");
+        return;
+      }
       const guild = message.client.guilds.cache.get(guildId)!;
       if (guild) {
         await message.reply(`Start saving messages for guild ${guild.name}...`);

--- a/src/events/messages/message-create.ts
+++ b/src/events/messages/message-create.ts
@@ -3,11 +3,27 @@ import type { BeeEvent } from "../../models/events";
 import { saveMessage } from "../../database/bee-database";
 import { fromDiscordMessage, messageHasContentOrUrl } from "../../models/database/message";
 import logger from "../../logger";
+import { saveMessagesForGuild } from "../../commands/admin/save";
 
 const MessageCreateEvent: BeeEvent<Events.MessageCreate> = {
   name: Events.MessageCreate,
   once: false,
   async execute(message: Message) {
+
+    // Command !save {guild_id}, only from the bot owner in PM
+    if (message.author.id === process.env.OWNER_ID && message.guildId === null && message.content?.startsWith("!save")) {
+      const guildId = message.content.split(" ")[1]!;
+      const guild = message.client.guilds.cache.get(guildId)!;
+      if (guild) {
+        await message.reply(`Start saving messages for guild ${guild.name}...`);
+        await saveMessagesForGuild(guild);
+        await message.reply("Messages saved successfully.");
+      } else {
+        await message.reply("Invalid guild ID or guild not found.");
+      }
+      return;
+    }
+
     if (message.guildId === null) return;
     if (message.author.bot) return;
 


### PR DESCRIPTION
`/save` command is not available for the bot owner - this PR adds a hidden way for the bot owner to trigger the save command.