### PR TITLE
fix: No CodeQL for pull requests

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,8 +14,6 @@ name: "CodeQL Advanced"
 on:
   push:
     branches: [ "master" ]
-  pull_request:
-    branches: [ "master" ]
   schedule:
     - cron: '35 7 * * 3'
 


### PR DESCRIPTION
CodeQL is running for every commit in pull requests. Should we disable it? @DonatienBaille